### PR TITLE
feat: add `output_dir` option, `get_witty_cache_dir` func, and `WITTY_FORCE_REBUILD` env var

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-dev = ['pytest', 'ruff', 'mypy', 'pdoc', 'pre-commit']
+dev = ['pytest', 'ruff', 'mypy', 'pdoc', 'pre-commit', 'ipython']
 
 [project.urls]
 homepage = "https://github.com/funkelab/witty"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,16 +16,16 @@ authors = [
   { email = "talley.lambert@gmail.com", name = "Talley Lambert" },
 ]
 dynamic = ["version"]
-dependencies = ["cython", "setuptools; python_version >= '3.12'"]
+dependencies = ["Cython >= 3.0,<3.2", "setuptools; python_version >= '3.12'"]
 classifiers = [
-    "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Typing :: Typed",
+  "License :: OSI Approved :: BSD License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Typing :: Typed",
 ]
 
 [project.optional-dependencies]

--- a/src/witty/__init__.py
+++ b/src/witty/__init__.py
@@ -6,6 +6,6 @@ except PackageNotFoundError:
     # package is not installed
     __version__ = "unknown"
 
-from .compile_module import compile_module
+from .compile_module import WITTY_CACHE, compile_module
 
-__all__ = ["compile_module"]
+__all__ = ["compile_module", "WITTY_CACHE"]

--- a/src/witty/__init__.py
+++ b/src/witty/__init__.py
@@ -6,6 +6,6 @@ except PackageNotFoundError:
     # package is not installed
     __version__ = "unknown"
 
-from .compile_module import WITTY_CACHE, compile_module
+from .compile_module import compile_module, get_witty_cache_dir
 
-__all__ = ["compile_module", "WITTY_CACHE"]
+__all__ = ["compile_module", "get_witty_cache_dir", "__version__"]

--- a/src/witty/compile_module.py
+++ b/src/witty/compile_module.py
@@ -95,10 +95,12 @@ def compile_module(
     quiet : bool, optional
         Suppress output except for errors and warnings.
     output_dir : Path, optional
-        Directory to store the compiled module. Defaults to a 'witty' subdirectory in
-        the Cython cache directory: `Cython.Utils.get_cython_cache_dir() / "witty"`.
-        Note that the output directory is also where the compiled module will be
-        searched for when reloading.
+        Directory to store the compiled module. If not provided, the module will be
+        stored in the default cache directory:
+        - os.environ["WITTY_CACHE_DIR"] if set
+        - Windows: `%LOCALAPPDATA%/witty/cache`
+        - macOS: `~/Library/Caches/witty`
+        - Linux: os.environ['XDG_CACHE_HOME']/witty or `~/.cache/witty`
     extension_kwargs : dict, optional
         Additional keyword arguments passed to the distutils `Extension` constructor.
 

--- a/src/witty/compile_module.py
+++ b/src/witty/compile_module.py
@@ -23,6 +23,11 @@ if TYPE_CHECKING:
 def get_witty_cache_dir() -> Path:
     """Return the base directory containing Witty's caches.
 
+    - os.environ["WITTY_CACHE_DIR"] if set
+    - Windows: `%LOCALAPPDATA%/witty/cache`
+    - macOS: `~/Library/Caches/witty`
+    - Linux: os.environ['XDG_CACHE_HOME']/witty or `~/.cache/witty`
+
     This function does not ensure that the directory exists.
     """
     if "WITTY_CACHE_DIR" in os.environ:

--- a/src/witty/compile_module.py
+++ b/src/witty/compile_module.py
@@ -7,12 +7,12 @@ import os
 import sys
 import tempfile
 from contextlib import contextmanager
+from distutils.command.build_ext import build_ext
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 import Cython
-from Cython.Build import cythonize
-from Cython.Build.Inline import build_ext
+from Cython.Build.Dependencies import cythonize
 from setuptools import Distribution, Extension
 
 if TYPE_CHECKING:
@@ -164,7 +164,7 @@ def compile_module(
                 **(extension_kwargs or {}),
             )
 
-            build_extension.extensions = cythonize(
+            build_extension.extensions = cythonize(  # type: ignore [no-untyped-call]
                 [extension],
                 compiler_directives={"language_level": "3"},
                 quiet=quiet,
@@ -199,7 +199,7 @@ def _generate_hash(
         arg_hash,
         sys.version_info,
         sys.executable,
-        Cython.__version__,
+        Cython.__version__,  # type: ignore [attr-defined]
     )
     return hashlib.md5(str(source_key).encode("utf-8")).hexdigest()
 

--- a/src/witty/compile_module.py
+++ b/src/witty/compile_module.py
@@ -96,7 +96,7 @@ def compile_module(
         Suppress output except for errors and warnings.
     output_dir : Path, optional
         Directory to store the compiled module. If not provided, the module will be
-        stored in the default cache directory:
+        stored in the output of `witty.get_witty_cache_dir()`:
         - os.environ["WITTY_CACHE_DIR"] if set
         - Windows: `%LOCALAPPDATA%/witty/cache`
         - macOS: `~/Library/Caches/witty`

--- a/src/witty/compile_module.py
+++ b/src/witty/compile_module.py
@@ -34,7 +34,7 @@ def compile_module(
     extra_compile_args: list[str] | None = None,
     extra_link_args: list[str] | None = None,
     name: str = "_witty_module",
-    force_rebuild: bool = False,
+    force_rebuild: bool | None = None,
     quiet: bool = False,
     output_dir: Path = WITTY_CACHE,
     **extension_kwargs: Any,
@@ -72,7 +72,8 @@ def compile_module(
     name : str, optional
         The base name of the module file. Defaults to "_witty_module".
     force_rebuild : bool, optional
-        Force a rebuild even if a module with the same name/hash already exists.
+        Force a rebuild even if a module with the same name/hash already exists. By
+        default False.  May be set via environment variable `WITTY_FORCE_REBUILD=1`.
     quiet : bool, optional
         Suppress output except for errors and warnings.
     output_dir : Path, optional
@@ -88,6 +89,9 @@ def compile_module(
     ModuleType
         The compiled module.
     """
+    if force_rebuild is None:
+        force_rebuild = os.getenv("WITTY_FORCE_REBUILD", "0").lower() in ("1", "true")
+
     module_hash = _generate_hash(
         source_pyx, source_files, extra_compile_args, extra_link_args, extension_kwargs
     )

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -40,4 +40,5 @@ def to_vector({type} x):
     assert result == 7
     assert type(result) is float
 
+    assert module_float.__file__
     assert Path(module_float.__file__).parent == tmp_path

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -3,6 +3,11 @@ from pathlib import Path
 import witty
 
 
+def test_cache_dir() -> None:
+    # smoke test to check if the cache dir is created
+    assert isinstance(witty.get_witty_cache_dir(), Path)
+
+
 def test_compile(tmp_path: Path) -> None:
     source_pxy_template = """
 cdef extern from '<vector>' namespace 'std':

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -1,7 +1,9 @@
+from pathlib import Path
+
 import witty
 
 
-def test_compile():
+def test_compile(tmp_path: Path) -> None:
     source_pxy_template = """
 cdef extern from '<vector>' namespace 'std':
 
@@ -20,7 +22,10 @@ def to_vector({type} x):
 """
 
     module_int = witty.compile_module(
-        source_pxy_template.format(type="int"), language="c++", force_rebuild=True
+        source_pxy_template.format(type="int"),
+        language="c++",
+        force_rebuild=True,
+        output_dir=tmp_path,
     )
     result = module_int.add(3, 4)
 
@@ -28,9 +33,11 @@ def to_vector({type} x):
     assert type(result) is int
 
     module_float = witty.compile_module(
-        source_pxy_template.format(type="float"), language="c++"
+        source_pxy_template.format(type="float"), language="c++", output_dir=tmp_path
     )
     result = module_float.add(3, 4)
 
     assert result == 7
     assert type(result) is float
+
+    assert Path(module_float.__file__).parent == tmp_path


### PR DESCRIPTION

* Added a new publicly exposed `get_witty_cache_dir` function in `src/witty/compile_module.py`.  No longer use Cython's cache dir.
* Added a new `output_dir` parameter to `compile_module`, allowing users to specify a custom directory for compiled modules (needed for spatial-graph to ship pre-compiled stuff)
* Modified `force_rebuild` to support configuration via the `WITTY_FORCE_REBUILD` environment variable.
* Updated the `pyproject.toml` file to specify a version range for `Cython` and added `ipython` to the development dependencies.