### PR TITLE
fix: pass source_files to extension

### DIFF
--- a/src/witty/compile_module.py
+++ b/src/witty/compile_module.py
@@ -475,7 +475,7 @@ def _compile_module(
 
             extension = Extension(
                 module_name,
-                sources=[str(module_source)],
+                sources=[str(module_source), *source_files],
                 include_dirs=[str(x) for x in include_dirs],
                 library_dirs=[str(x) for x in library_dirs],
                 language=language,


### PR DESCRIPTION
when porting waterz to use witty, I got link errors ("symbol not found in flat namespace"...), and eventually realized that witty isn't actually passing source_files to distutils `Extension` (they're only being used to calculate the hashes).  I believe this small change is correct and necessary.